### PR TITLE
Reorder exports.require above exports.node so that Node.js allows importing the package from a CommonJS (default) context

### DIFF
--- a/libs/bunny-storage/package.json
+++ b/libs/bunny-storage/package.json
@@ -7,9 +7,9 @@
   "exports": {
     ".": {
       "deno": "./esm/lib.mjs",
+      "require": "./dist/lib.js",
       "node": "./esm-node/lib.mjs",
       "import": "./esm/lib.mjs",
-      "require": "./dist/lib.js",
       "types": "./dist/_tsup-dts-rollup.d.ts"
     }
   },


### PR DESCRIPTION
Reordering the exports like this ensures that `require('@bunny.net/storage-sdk')` works.