### PR TITLE
Add DE to ZoneSchema

### DIFF
--- a/libs/bunny-storage/src/file.ts
+++ b/libs/bunny-storage/src/file.ts
@@ -17,7 +17,8 @@ export const ZoneSchema = z.union([
   z.literal("BR"),
   z.literal("SG"),
   z.literal("JP"),
-  z.literal("SYD")
+  z.literal("SYD"),
+  z.literal("DE")
 ]);
 
 export type Zone = z.infer<typeof ZoneSchema>;


### PR DESCRIPTION
I recently setup a NY storage with replication on Frankfurt (DE), and got Zod yelling at me for not having it mapped in ZoneSchema. This PR is adding it to the schema.