### PR TITLE
Make options parameter optional in servePullZone

### DIFF
--- a/.changeset/moody-ways-wave.md
+++ b/.changeset/moody-ways-wave.md
@@ -1,0 +1,5 @@
+---
+"@bunny.net/edgescript-sdk": patch
+---
+
+`servePullZone` should allow to be used without an argument

--- a/libs/bunny-sdk/src/net/serve.ts
+++ b/libs/bunny-sdk/src/net/serve.ts
@@ -189,7 +189,7 @@ export type PullZoneHandler = {
  *   });
  * ```
  */
-function servePullZone(options: PullZoneHandlerOptions): PullZoneHandler;
+function servePullZone(options?: PullZoneHandlerOptions): PullZoneHandler;
 function servePullZone(
   listener: { port: number; hostname: string },
   options: PullZoneHandlerOptions,


### PR DESCRIPTION
# Git Changes Summary

## Core Changes

1. **Function signature update** in `servePullZone`:
   - Changed `options: PullZoneHandlerOptions` to `options?: PullZoneHandlerOptions`
   - The `options` parameter is now **optional** (marked with `?`)

2. **Changeset added**: Documents this as a patch-level change to `@bunny.net/edgescript-sdk`

## Fixes

- https://github.com/BunnyWay/edge-script-sdk/issues/65