### PR TITLE
fix: Remove unnecessary double parse and console.error in storage list function

### DIFF
--- a/.changeset/rare-brooms-invite.md
+++ b/.changeset/rare-brooms-invite.md
@@ -1,0 +1,5 @@
+---
+"@bunny.net/storage-sdk": patch
+---
+
+Remove unseless double parse & console.error log

--- a/libs/bunny-storage/src/file.ts
+++ b/libs/bunny-storage/src/file.ts
@@ -188,12 +188,6 @@ export async function list(storageZone: StorageZone.StorageZone, path: string): 
 
   const j = await response.json();
 
-  try {
-    StorageFileListing.parse(j);
-  } catch (e) {
-    console.error(e);
-  }
-
   return StorageFileListing.parse(j).map(result => ({
     _tag: "StorageFile",
     guid: result.Guid,


### PR DESCRIPTION
# Git Changes Summary

## Core Changes

1. **Removed redundant parsing** in `libs/bunny-storage/src/file.ts`:
   - Eliminated a try-catch block that was parsing `StorageFileListing` twice
   - Removed `console.error` logging
   - Now parsing happens only once (the second parse operation)

2. **Added changeset** documenting this as a patch release that removes "useless double parse & console.error log"

## Fixes

- https://github.com/BunnyWay/edge-script-sdk/issues/66