### PR TITLE
fix: set upstream response status in middleware on Node.js runtime

### DIFF
--- a/libs/bunny-sdk/src/net/serve.ts
+++ b/libs/bunny-sdk/src/net/serve.ts
@@ -296,7 +296,10 @@ function servePullZone(
             ) {
               const body = await prevResponse.text();
               headers.delete("content-encoding");
-              response = new Response(body, { headers });
+              response = new Response(body, {
+                ...prevResponse,
+                headers,
+              });
             } else {
               response = new Response(prevResponse.body, {
                 ...prevResponse,


### PR DESCRIPTION
Fix issue #76 by initializing the middleware response using the upstream responses's `status` and `statusText` on Node.js runtime, similarly to others.