### PR TITLE
build(bunny-storage): move dotenv to devDependencies

### DIFF
--- a/.changeset/happy-sheep-drive.md
+++ b/.changeset/happy-sheep-drive.md
@@ -1,0 +1,5 @@
+---
+"@bunny.net/storage-sdk": patch
+---
+
+move dotenv to devDependencies

--- a/libs/bunny-storage/package.json
+++ b/libs/bunny-storage/package.json
@@ -47,6 +47,7 @@
     "@typescript-eslint/eslint-plugin": "^8.0.1",
     "@typescript-eslint/parser": "^8.0.1",
     "@vercel/ncc": "^0.38.1",
+    "dotenv": "^16.4.7",
     "esbuild": "0.23.0",
     "eslint": "^9.8.0",
     "globals": "^15.9.0",
@@ -61,7 +62,6 @@
     "ulid": "^2.3.0"
   },
   "dependencies": {
-    "dotenv": "^16.4.7",
     "zod": "^3.24.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -195,9 +195,6 @@ importers:
 
   libs/bunny-storage:
     dependencies:
-      dotenv:
-        specifier: ^16.4.7
-        version: 16.4.7
       zod:
         specifier: ^3.24.2
         version: 3.24.2
@@ -226,6 +223,9 @@ importers:
       '@vercel/ncc':
         specifier: ^0.38.1
         version: 0.38.1
+      dotenv:
+        specifier: ^16.4.7
+        version: 16.4.7
       esbuild:
         specifier: 0.23.0
         version: 0.23.0


### PR DESCRIPTION
`dotenv` is only used in the fike `jest.config.js` for test setup, and some examples. Not actually used for any runtime code.