### PR TITLE
feat(bunny-storage): add opt-in throwOnError for remove/removeDirectory

### DIFF
--- a/.changeset/many-berries-move.md
+++ b/.changeset/many-berries-move.md
@@ -1,0 +1,5 @@
+---
+"@bunny.net/storage-sdk": patch
+---
+
+handle throw on error for remove/removeDirectory

--- a/libs/bunny-storage/src/file.test.ts
+++ b/libs/bunny-storage/src/file.test.ts
@@ -253,6 +253,28 @@ describe('StorageFile operations', () => {
 
       expect(result).toBe(true);
     });
+
+    it('should resolve to false on failure by default', async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        status: 404
+      });
+
+      const result = await File.removeDirectory(mockStorageZone, '/test/missing-folder');
+
+      expect(result).toBe(false);
+    });
+
+    it('should throw on failure when throwOnError is set', async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        status: 404
+      });
+
+      await expect(
+        File.removeDirectory(mockStorageZone, '/test/missing-folder', { throwOnError: true })
+      ).rejects.toThrow('File not found');
+    });
   });
 
   describe('remove function', () => {
@@ -274,6 +296,28 @@ describe('StorageFile operations', () => {
       );
 
       expect(result).toBe(true);
+    });
+
+    it('should resolve to false on failure by default', async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        status: 404
+      });
+
+      const result = await File.remove(mockStorageZone, '/test/missing.txt');
+
+      expect(result).toBe(false);
+    });
+
+    it('should throw on failure when throwOnError is set', async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        status: 404
+      });
+
+      await expect(
+        File.remove(mockStorageZone, '/test/missing.txt', { throwOnError: true })
+      ).rejects.toThrow('File not found');
     });
   });
 });

--- a/libs/bunny-storage/src/file.ts
+++ b/libs/bunny-storage/src/file.ts
@@ -218,6 +218,10 @@ export type RemoveOptions = {
    *
    * Defaults to `false` to preserve backwards compatibility: by default a
    * failed request still resolves to `false`.
+   *
+   * @deprecated The opt-in is temporary. In v1 throwing becomes the default
+   * behaviour and this option (along with the `boolean` return) will be
+   * removed. Adopt `{ throwOnError: true }` now to ease the migration.
    */
   throwOnError?: boolean;
 };

--- a/libs/bunny-storage/src/file.ts
+++ b/libs/bunny-storage/src/file.ts
@@ -209,16 +209,38 @@ export async function list(storageZone: StorageZone.StorageZone, path: string): 
 }
 
 /**
+ * Options for the deletion operations ([remove], [removeDirectory]).
+ */
+export type RemoveOptions = {
+  /**
+   * When `true`, the operation throws on a failed request (mirroring the
+   * behaviour of [upload] and [download]) instead of resolving to `false`.
+   *
+   * Defaults to `false` to preserve backwards compatibility: by default a
+   * failed request still resolves to `false`.
+   */
+  throwOnError?: boolean;
+};
+
+/**
  * Remove files and folders in a directory from a [StorageZone].
  *
- * @throws
+ * By default a failed request resolves to `false`. Pass
+ * `{ throwOnError: true }` to instead throw on failure, mirroring [upload]
+ * and [download].
+ *
+ * @throws When the request fails and `options.throwOnError` is `true`.
  */
-export async function remove(storageZone: StorageZone.StorageZone, path: string): Promise<boolean> {
+export async function remove(storageZone: StorageZone.StorageZone, path: string, options?: RemoveOptions): Promise<boolean> {
   const url = StorageZone.addr(storageZone);
   url.pathname = `${url.pathname}${path}`;
 
   const [auth_header, key] = StorageZone.key(storageZone);
   const response = await fetch(url, { method: "DELETE", headers: { [auth_header]: key } });
+
+  if (!response.ok && options?.throwOnError) {
+    throw statusCodeToException(storageZone, response.status, path);
+  }
 
   return response.ok;
 }
@@ -241,14 +263,22 @@ export async function createDirectory(storageZone: StorageZone.StorageZone, path
 /**
  * Remove recursively a Directory in the [StorageZone].
  *
- * @throws
+ * By default a failed request resolves to `false`. Pass
+ * `{ throwOnError: true }` to instead throw on failure, mirroring [upload]
+ * and [download].
+ *
+ * @throws When the request fails and `options.throwOnError` is `true`.
  */
-export async function removeDirectory(storageZone: StorageZone.StorageZone, path: string): Promise<boolean> {
+export async function removeDirectory(storageZone: StorageZone.StorageZone, path: string, options?: RemoveOptions): Promise<boolean> {
   const url = StorageZone.addr(storageZone);
   const directory_path = path.endsWith("/") ? path : `${path}/`;
   url.pathname = `${url.pathname}${directory_path}`;
   const [auth_header, key] = StorageZone.key(storageZone);
   const response = await fetch(url, { method: "DELETE", headers: { [auth_header]: key } });
+
+  if (!response.ok && options?.throwOnError) {
+    throw statusCodeToException(storageZone, response.status, path);
+  }
 
   return response.ok;
 }


### PR DESCRIPTION
`remove() and removeDirectory()` resolve to `false` on a failed request which hides the real status from callers. Add an optional `RemoveOptions` arg with `throwOnError` (default `false`) so consumers can opt into throwing on failure, mirroring `upload()/download()`.


Default behaviour is unchanged, so existing users are unaffected.

Only two comments...