### PR TITLE
refactor(bunny-storage): de-duplicate file internals and tidy errors/docs

### DIFF
--- a/.changeset/quick-pandas-clean.md
+++ b/.changeset/quick-pandas-clean.md
@@ -1,0 +1,5 @@
+---
+"@bunny.net/storage-sdk": patch
+---
+
+simplify file internals: share StorageFile construction between get/list and add a named FileDownload type

--- a/.changeset/sharp-otters-report.md
+++ b/.changeset/sharp-otters-report.md
@@ -1,0 +1,5 @@
+---
+"@bunny.net/storage-sdk": patch
+---
+
+fix misleading 400 error message that mentioned uploading on every operation (get/list/download/remove)

--- a/libs/bunny-storage/src/file.ts
+++ b/libs/bunny-storage/src/file.ts
@@ -23,6 +23,16 @@ export const ZoneSchema = z.union([
 export type Zone = z.infer<typeof ZoneSchema>;
 
 /**
+ * The result of downloading a [StorageFile]: the body as a stream, the raw
+ * [Response], and the content length when the server reports it.
+ */
+export type FileDownload = {
+  stream: ReadableStream<Uint8Array>;
+  response: Response;
+  length?: number;
+};
+
+/**
  * A [StorageFile] stored in a Storage Zone.
  *
  * Can be a Folder (fake folder)
@@ -91,18 +101,45 @@ export type StorageFile = {
    * have the stream which will fetch the content of the body of the file you
    * want.
    */
-  data: () => Promise<{
-    stream: ReadableStream<Uint8Array>;
-    response: Response;
-    length?: number;
-  }>,
+  data: () => Promise<FileDownload>,
 };
+
+/**
+ * Build a [StorageFile] from a parsed API record.
+ *
+ * `downloadPath` is the path used by `data()` to fetch the body: [get] passes
+ * the requested path, while [list] passes each entry's own `Path`.
+ */
+function toStorageFile(
+  storageZone: StorageZone.StorageZone,
+  result: z.infer<typeof StorageFileSchemaDescribe>,
+  downloadPath: string,
+): StorageFile {
+  return {
+    _tag: "StorageFile",
+    guid: result.Guid,
+    userId: result.UserId,
+    lastChanged: result.LastChanged,
+    dateCreated: result.DateCreated,
+    storageZoneName: result.StorageZoneName,
+    path: result.Path,
+    objectName: result.ObjectName,
+    length: result.Length,
+    storageZoneId: result.StorageZoneId,
+    isDirectory: result.IsDirectory,
+    serverId: result.ServerId,
+    checksum: result.Checksum,
+    replicatedZones: result.ReplicatedZones,
+    contentType: result.ContentType,
+    data: () => download(storageZone, downloadPath),
+  };
+}
 
 /**
  * Fetch the metadata of a file from a [StorageZone], to have the data of this
  * file, you'll need to download it.
  *
- * You can download the content of a [StorageFile] by awaitng the `data()`
+ * You can download the content of a [StorageFile] by awaiting the `data()`
  * function of this file.
  *
  * @throws
@@ -123,7 +160,7 @@ export type StorageFile = {
  *   // Here the body will be in the `stream` file, you can collect it in whatever
  *   // way you need.
  *   // The response will contain the rest of the metadata available.
- *   let promise_to_fetch_the_file: { stream: ReadableStream<Uint8Array>; response: Response; length?: number; } = await file.data();
+ *   let promise_to_fetch_the_file: BunnyStorageSDK.file.FileDownload = await file.data();
  * ```
  */
 export async function get(storageZone: StorageZone.StorageZone, path: string): Promise<StorageFile> {
@@ -150,24 +187,7 @@ export async function get(storageZone: StorageZone.StorageZone, path: string): P
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const result = StorageFileSchemaDescribe.parse(processedData as unknown as any);
 
-  return ({
-    _tag: "StorageFile",
-    guid: result.Guid,
-    userId: result.UserId,
-    lastChanged: result.LastChanged,
-    dateCreated: result.DateCreated,
-    storageZoneName: result.StorageZoneName,
-    path: result.Path,
-    objectName: result.ObjectName,
-    length: result.Length,
-    storageZoneId: result.StorageZoneId,
-    isDirectory: result.IsDirectory,
-    serverId: result.ServerId,
-    checksum: result.Checksum,
-    replicatedZones: result.ReplicatedZones,
-    contentType: result.ContentType,
-    data: () => download(storageZone, path),
-  })
+  return toStorageFile(storageZone, result, path);
 }
 
 /**
@@ -188,24 +208,9 @@ export async function list(storageZone: StorageZone.StorageZone, path: string): 
 
   const j = await response.json();
 
-  return StorageFileListing.parse(j).map(result => ({
-    _tag: "StorageFile",
-    guid: result.Guid,
-    userId: result.UserId,
-    lastChanged: result.LastChanged,
-    dateCreated: result.DateCreated,
-    storageZoneName: result.StorageZoneName,
-    path: result.Path,
-    objectName: result.ObjectName,
-    length: result.Length,
-    storageZoneId: result.StorageZoneId,
-    isDirectory: result.IsDirectory,
-    serverId: result.ServerId,
-    checksum: result.Checksum,
-    replicatedZones: result.ReplicatedZones,
-    contentType: result.ContentType,
-    data: () => download(storageZone, result.Path),
-  }));
+  return StorageFileListing.parse(j).map(result =>
+    toStorageFile(storageZone, result, result.Path),
+  );
 }
 
 /**
@@ -332,15 +337,11 @@ export async function upload(storageZone: StorageZone.StorageZone, path: string,
 }
 
 /**
- * Download a Stream to a [StorageZone].
+ * Download a Stream from a [StorageZone].
  *
  * @throws
  */
-export async function download(storageZone: StorageZone.StorageZone, path: string): Promise<{
-  stream: ReadableStream<Uint8Array>;
-  response: Response;
-  length?: number;
-}> {
+export async function download(storageZone: StorageZone.StorageZone, path: string): Promise<FileDownload> {
   const url = StorageZone.addr(storageZone);
   url.pathname = `${url.pathname}${path}`;
 
@@ -372,7 +373,7 @@ function statusCodeToException(storageZone: StorageZone.StorageZone, status: num
     case 404:
       return new Error(`File not found: ${path}`);
     case 400:
-      return new Error("Unable to upload file. Either invalid path specified, either provided checksum invalid");
+      return new Error(`Bad request for ${path}: invalid path or checksum.`);
     case 401:
       return new Error(
         `Unauthorized access to storage zone: ${StorageZone.name(storageZone)}`,

--- a/libs/bunny-storage/src/zone.ts
+++ b/libs/bunny-storage/src/zone.ts
@@ -7,7 +7,7 @@ export type StorageZone = {
   name: string,
 
   // If this is set up, the reading will not goes into the API but it'll goes to
-  // the associated PZ, it'll increase greatly the scalibility of the read & the
+  // the associated PZ, it'll increase greatly the scalability of the read & the
   // performance.
   // Especially if caching is activated on a PullZone.
   // optimized_reading_pz: null,
@@ -32,7 +32,7 @@ export function name(value: StorageZone): string {
 }
 
 /**
- * Give the associated Authentification header with it's content.
+ * Give the associated Authentication header with its content.
  */
 export function key(value: StorageZone): [string, string] {
   return ["AccessKey", value.accessKey]


### PR DESCRIPTION
- Removed duplicate code between `get()` and `list()`
-Added a `FileDownload` type
- Clearer 400 error message (Upload error message on any failed response)
- Fixed doc typos